### PR TITLE
Update BasicMachineHealthV2.md

### DIFF
--- a/specification/BasicMachineHealthV2.md
+++ b/specification/BasicMachineHealthV2.md
@@ -13,7 +13,6 @@
 | Key                  | Req. Level | Type          | Unit  | Description                                             |
 |-------------------------|-----------|--------------|------|---------------------------------------------------------|
 | `"FuelLevel"`           | shall     | integer      | %    | Current Fuel level as percentage of full capacity. Range 0-100.    |
-| `"AdBlueLevel"`         | should    | integer      | %    | Current AdBlue (Diesel Exhaust Fluid) level as percentage of full capacity. Range 0-100.  |
 | `"TotalMachineHour"`    | should    | decimal      | h    | Number of hours the Machine has been running.       |
 | `"TotalEngineHour"`     | shall     | decimal      | h    | Number of hours the Engine has been running.        | 
 | `"Tire"`               | should    | Object Array | -    | A list of tire information       | 
@@ -34,7 +33,6 @@
   "EquipmentId": "f4d95a41-831e-4a27-9353-32872b7d6103",
   "BasicMachineHealthV2": {
   "FuelLevel": 74,
-  "AdBlueLevel": null,
   "TotalMachineHour": 4511.4,
   "TotalEngineHour": 93.1,
   "Tire": [

--- a/specification/BasicMachineHealthV2.md
+++ b/specification/BasicMachineHealthV2.md
@@ -8,17 +8,23 @@
 
 | Key                  | Req. Level | Type          | Unit  | Description                                             |
 |-------------------------|-----------|--------------|------|---------------------------------------------------------|
-| `"FuelLevel"`           | shall     | integer      | %    | Current Fuel level                   |
-| `"TotalMachineHour"`    | should    | decimal      | h    | Number of hours the Machine has been running       |
-| `"TotalEngineHour"`     | shall     | decimal      | h    | Number of hours the Machine has been running        | 
+| `"FuelLevel"`           | shall     | integer      | %    | Current Fuel level as percentage of full capacity. Range 0-100. If unavailable or sensor error, value shall be null.    |
+| `"AdBlueLevel"`         | should    | integer      | %    | Current AdBlue (Diesel Exhaust Fluid) level as percentage of full capacity. Range 0-100. If unavailable or sensor error, value shall be null.  |
+| `"TotalMachineHour"`    | should    | decimal      | h    | Number of hours the Machine has been running. If unavailable, value shall be null.       |
+| `"TotalEngineHour"`     | shall     | decimal      | h    | Number of hours the Engine has been running. If unavailable, value shall be null.        | 
 | `"Tire"`               | should    | Object Array | -    | A list of tire information       | 
 
 ### Array Of `[ ]`
 | Key             | Req. Level | Type    | Unit  | Description                            | 
 |-------------------|-----------|--------|------|--------------------------------|
 | `"TirePosition"`  | shall     | string  | -    |           |       
-| `"TirePressure"`  | shall     | integer | kPa  | Pressure for the actual tire      |
-| `"TireTemperature"` | shall     | integer | °C   | Temperature for the actual tire       |
+| `"TirePressure"`  | shall     | integer | kPa  | Pressure for the actual tire. If unavailable or sensor error, the value shall be null.      |
+| `"TireTemperature"` | shall     | integer | °C   | Temperature for the actual tire. If unavailable or sensor error, the value shall be null.       |
+> [!NOTE]
+> All numeric attributes in `BasicMachineHealthV2` **may be null**.\
+> A `null` value **shall indicate** that the corresponding sensor value or signal is unavailable or that a measurement error occurred.\
+> Implementations **shall not** substitute default numeric values for missing data.
+
 
 # BasicMachineHealthV2 Message Example
 ```json
@@ -29,6 +35,7 @@
   "EquipmentId": "f4d95a41-831e-4a27-9353-32872b7d6103",
   "BasicMachineHealthV2": {
   "FuelLevel": 74,
+  "AdBlueLevel": null,
   "TotalMachineHour": 4511.4,
   "TotalEngineHour": 93.1,
   "Tire": [

--- a/specification/BasicMachineHealthV2.md
+++ b/specification/BasicMachineHealthV2.md
@@ -17,7 +17,7 @@
 ### Array Of `[ ]`
 | Key             | Req. Level | Type    | Unit  | Description                            | 
 |-------------------|-----------|--------|------|--------------------------------|
-| `"TirePosition"`  | shall     | string  | -    |           |       
+| `"TirePosition"`  | shall     | string  | -    | Tire position identifier, as defined in ISO 23725:2023, Clause 4.2.5     |       
 | `"TirePressure"`  | shall     | integer | kPa  | Pressure for the actual tire. If unavailable or sensor error, the value shall be null.      |
 | `"TireTemperature"` | shall     | integer | °C   | Temperature for the actual tire. If unavailable or sensor error, the value shall be null.       |
 > [!NOTE]

--- a/specification/BasicMachineHealthV2.md
+++ b/specification/BasicMachineHealthV2.md
@@ -4,27 +4,26 @@
 |---|---|
 |`AHS` |  At Runtime change |
 
+> [!IMPORTANT]
+> All numeric attributes in `BasicMachineHealthV2` **may be null**.\
+> A `null` value **shall indicate** that the corresponding sensor value or signal is unavailable or that a measurement error occurred.\
+> Implementations **shall not** substitute default numeric values for missing data.
 ## Message attributes
 
 | Key                  | Req. Level | Type          | Unit  | Description                                             |
 |-------------------------|-----------|--------------|------|---------------------------------------------------------|
-| `"FuelLevel"`           | shall     | integer      | %    | Current Fuel level as percentage of full capacity. Range 0-100. If unavailable or sensor error, value shall be null.    |
-| `"AdBlueLevel"`         | should    | integer      | %    | Current AdBlue (Diesel Exhaust Fluid) level as percentage of full capacity. Range 0-100. If unavailable or sensor error, value shall be null.  |
-| `"TotalMachineHour"`    | should    | decimal      | h    | Number of hours the Machine has been running. If unavailable, value shall be null.       |
-| `"TotalEngineHour"`     | shall     | decimal      | h    | Number of hours the Engine has been running. If unavailable, value shall be null.        | 
+| `"FuelLevel"`           | shall     | integer      | %    | Current Fuel level as percentage of full capacity. Range 0-100.    |
+| `"AdBlueLevel"`         | should    | integer      | %    | Current AdBlue (Diesel Exhaust Fluid) level as percentage of full capacity. Range 0-100.  |
+| `"TotalMachineHour"`    | should    | decimal      | h    | Number of hours the Machine has been running.       |
+| `"TotalEngineHour"`     | shall     | decimal      | h    | Number of hours the Engine has been running.        | 
 | `"Tire"`               | should    | Object Array | -    | A list of tire information       | 
 
 ### Array Of `[ ]`
 | Key             | Req. Level | Type    | Unit  | Description                            | 
 |-------------------|-----------|--------|------|--------------------------------|
 | `"TirePosition"`  | shall     | string  | -    | Tire position identifier, as defined in ISO 23725:2023, Clause 4.2.5     |       
-| `"TirePressure"`  | shall     | integer | kPa  | Pressure for the actual tire. If unavailable or sensor error, the value shall be null.      |
-| `"TireTemperature"` | shall     | integer | °C   | Temperature for the actual tire. If unavailable or sensor error, the value shall be null.       |
-> [!NOTE]
-> All numeric attributes in `BasicMachineHealthV2` **may be null**.\
-> A `null` value **shall indicate** that the corresponding sensor value or signal is unavailable or that a measurement error occurred.\
-> Implementations **shall not** substitute default numeric values for missing data.
-
+| `"TirePressure"`  | shall     | integer | kPa  | Pressure for the actual tire.                                            |
+| `"TireTemperature"` | shall     | integer | °C   | Temperature for the actual tire.                                       |
 
 # BasicMachineHealthV2 Message Example
 ```json


### PR DESCRIPTION
- Added AdBlue level.
- All numeric values are now nullable. A null value shall indicate that the value is unavailable or that a sensor error has occurred.